### PR TITLE
Add WASM caching and optimize API service methods

### DIFF
--- a/src/sequencer/api/ApiService.ts
+++ b/src/sequencer/api/ApiService.ts
@@ -24,11 +24,11 @@ export class VocdoniApiService extends BaseService {
         super(baseURL);
     }
 
-    async ping(): Promise<void> {
-        await this.request({ method: "GET", url: "/ping" });
+    ping(): Promise<void> {
+        return this.request({ method: "GET", url: "/ping" });
     }
 
-    async createProcess(body: CreateProcessRequest): Promise<CreateProcessResponse> {
+    createProcess(body: CreateProcessRequest): Promise<CreateProcessResponse> {
         return this.request({
             method: "POST",
             url: "/processes",
@@ -36,88 +36,83 @@ export class VocdoniApiService extends BaseService {
         });
     }
 
-    async getProcess(processId: string): Promise<GetProcessResponse> {
+    getProcess(processId: string): Promise<GetProcessResponse> {
         return this.request({
             method: "GET",
             url: `/processes/${processId}`
         });
     }
 
-    async createCensus(): Promise<string> {
-        const res = await this.request<{ census: string }>({
+    createCensus(): Promise<string> {
+        return this.request<{ census: string }>({
             method: "POST",
             url: "/censuses"
-        });
-        return res.census;
+        }).then(res => res.census);
     }
 
-    async addParticipants(censusId: string, participants: CensusParticipant[]): Promise<void> {
+    addParticipants(censusId: string, participants: CensusParticipant[]): Promise<void> {
         if (!isUUId(censusId)) throw new Error("Invalid census ID format");
 
-        await this.request({
+        return this.request({
             method: "POST",
             url: `/censuses/${censusId}/participants`,
             data: { participants }
         });
     }
 
-    async getParticipants(censusId: string): Promise<CensusParticipant[]> {
+    getParticipants(censusId: string): Promise<CensusParticipant[]> {
         if (!isUUId(censusId)) throw new Error("Invalid census ID format");
 
-        const res = await this.request<{ participants: CensusParticipant[] }>({
+        return this.request<{ participants: CensusParticipant[] }>({
             method: "GET",
             url: `/censuses/${censusId}/participants`
-        });
-        return res.participants;
+        }).then(res => res.participants);
     }
 
-    async getCensusRoot(censusId: string): Promise<string> {
+    getCensusRoot(censusId: string): Promise<string> {
         if (!isUUId(censusId)) throw new Error("Invalid census ID format");
 
-        const res = await this.request<{ root: string }>({
+        return this.request<{ root: string }>({
             method: "GET",
             url: `/censuses/${censusId}/root`
-        });
-        return res.root;
+        }).then(res => res.root);
     }
 
-    async getCensusSize(censusId: string): Promise<number> {
+    getCensusSize(censusId: string): Promise<number> {
         if (!isUUId(censusId)) throw new Error("Invalid census ID format");
 
-        const res = await this.request<{ size: number }>({
+        return this.request<{ size: number }>({
             method: "GET",
             url: `/censuses/${censusId}/size`
-        });
-        return res.size;
+        }).then(res => res.size);
     }
 
-    async deleteCensus(censusId: string): Promise<void> {
+    deleteCensus(censusId: string): Promise<void> {
         if (!isUUId(censusId)) throw new Error("Invalid census ID format");
 
-        await this.request({
+        return this.request({
             method: "DELETE",
             url: `/censuses/${censusId}`
         });
     }
 
-    async getCensusProof(censusRoot: string, key: string): Promise<CensusProof> {
-        return await this.request<CensusProof>({
+    getCensusProof(censusRoot: string, key: string): Promise<CensusProof> {
+        return this.request<CensusProof>({
             method: "GET",
             url: `/censuses/${censusRoot}/proof`,
             params: {key}
         });
     }
 
-    async submitVote(vote: VoteRequest): Promise<string> {
-        const { voteId } = await this.request<{ voteId: string }>({
+    submitVote(vote: VoteRequest): Promise<string> {
+        return this.request<{ voteId: string }>({
             method: "POST",
             url: "/votes",
             data: vote,
-        });
-        return voteId;
+        }).then(res => res.voteId);
     }
 
-    async getVoteStatus(
+    getVoteStatus(
         processId: string,
         voteId: string
     ): Promise<VoteStatusResponse> {
@@ -127,26 +122,25 @@ export class VocdoniApiService extends BaseService {
         });
     }
 
-    async getInfo(): Promise<InfoResponse> {
+    getInfo(): Promise<InfoResponse> {
         return this.request<InfoResponse>({
             method: "GET",
             url: "/info"
         });
     }
 
-    async pushMetadata(metadata: ElectionMetadata): Promise<string> {
-        const { hash } = await this.request<{ hash: string }>({
+    pushMetadata(metadata: ElectionMetadata): Promise<string> {
+        return this.request<{ hash: string }>({
             method: "POST",
             url: "/metadata",
             data: metadata
-        });
-        return hash;
+        }).then(res => res.hash);
     }
 
-    async getMetadata(hash: string): Promise<ElectionMetadata> {
+    getMetadata(hash: string): Promise<ElectionMetadata> {
         if (!isHexString(hash)) throw new Error("Invalid metadata hash format");
 
-        return await this.request<ElectionMetadata>({
+        return this.request<ElectionMetadata>({
             method: "GET",
             url: `/metadata/${hash}`
         });

--- a/test/sequencer/unit/BallotProof.test.ts
+++ b/test/sequencer/unit/BallotProof.test.ts
@@ -1,0 +1,213 @@
+import { BallotProof, BallotProofInputs } from '../../../src/sequencer';
+
+describe('BallotProof caching', () => {
+    let service: BallotProof;
+    let fetchSpy: jest.SpyInstance;
+
+    // Mock Go runtime
+    const mockGo = {
+        importObject: {},
+        run: jest.fn().mockImplementation(() => {
+            const promise = Promise.resolve();
+            // Ensure the promise has a catch method that returns the promise
+            promise.catch = () => promise;
+            return promise;
+        })
+    };
+
+    // Mock instance for WebAssembly
+    const mockInstance = {
+        exports: {
+            memory: new WebAssembly.Memory({ initial: 256 }),
+            add: (a: number, b: number) => a + b
+        }
+    };
+
+    // Mock BallotProofWasm with proper return value
+    const mockBallotProofWasm = {
+        proofInputs: jest.fn().mockImplementation((inputJson: string) => {
+            return {
+                error: null,
+                data: JSON.stringify({
+                    processID: '0x456',
+                    address: '0x123',
+                    commitment: 'mock-commitment',
+                    nullifier: 'mock-nullifier',
+                    ballot: {
+                        curveType: 'mock-curve',
+                        ciphertexts: []
+                    },
+                    ballotInputHash: 'mock-hash',
+                    voteID: 'mock-vote-id',
+                    circomInputs: {}
+                })
+            };
+        })
+    };
+
+    // Minimal test inputs
+    const testInputs: BallotProofInputs = {
+        address: '0x123',
+        processID: '0x456',
+        secret: '789',
+        encryptionKey: ['1', '2'],
+        k: '3',
+        weight: '4',
+        fieldValues: ['5'],
+        ballotMode: {
+            maxCount: 1,
+            forceUniqueness: false,
+            maxValue: '10',
+            minValue: '0',
+            maxTotalCost: '10',
+            minTotalCost: '0',
+            costExponent: 1,
+            costFromWeight: false
+        }
+    };
+
+    beforeEach(() => {
+        // Reset all mocks and clear caches
+        jest.resetAllMocks();
+        BallotProof['wasmExecCache'].clear();
+        BallotProof['wasmBinaryCache'].clear();
+
+        // Spy on fetch before mocking
+        fetchSpy = jest.spyOn(global, 'fetch');
+
+        // Mock fetch responses
+        fetchSpy.mockImplementation((url: string) => {
+            if (url.endsWith('wasm_exec.js')) {
+                return Promise.resolve({
+                    ok: true,
+                    text: () => Promise.resolve('/* mock wasm_exec.js */')
+                });
+            } else if (url.endsWith('ballotproof.wasm')) {
+                return Promise.resolve({
+                    ok: true,
+                    arrayBuffer: () => Promise.resolve(new ArrayBuffer(256))
+                });
+            }
+            return Promise.reject(new Error(`Unexpected URL: ${url}`));
+        });
+
+        // Mock WebAssembly.instantiate
+        global.WebAssembly = {
+            ...global.WebAssembly,
+            instantiate: jest.fn().mockResolvedValue({ instance: mockInstance })
+        } as any;
+
+        // Mock global Go constructor
+        global.Go = jest.fn().mockImplementation(() => mockGo) as any;
+
+        // Mock global BallotProofWasm
+        Object.defineProperty(global, 'BallotProofWasm', {
+            value: mockBallotProofWasm,
+            writable: true,
+            configurable: true
+        });
+
+        // Create a fresh instance for each test
+        service = new BallotProof({
+            wasmExecUrl: 'http://example.com/wasm_exec.js',
+            wasmUrl: 'http://example.com/ballotproof.wasm'
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should cache wasm_exec.js and ballotproof.wasm after first init()', async () => {
+        // First initialization should fetch both files
+        await service.init();
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/wasm_exec.js');
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/ballotproof.wasm');
+
+        // Reset spy counts
+        jest.clearAllMocks();
+
+        // Create new instance with same URLs
+        const service2 = new BallotProof({
+            wasmExecUrl: 'http://example.com/wasm_exec.js',
+            wasmUrl: 'http://example.com/ballotproof.wasm'
+        });
+
+        // Second initialization should use cached files
+        await service2.init();
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('should fetch new files for different URLs', async () => {
+        // First initialization with original URLs
+        await service.init();
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+        jest.clearAllMocks();
+
+        // Create new instance with different URLs
+        const service2 = new BallotProof({
+            wasmExecUrl: 'http://example.com/different_wasm_exec.js',
+            wasmUrl: 'http://example.com/different_ballotproof.wasm'
+        });
+
+        // Should fetch new files
+        await service2.init();
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/different_wasm_exec.js');
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/different_ballotproof.wasm');
+    });
+
+    it('should handle fetch failures appropriately', async () => {
+        // Mock fetch to fail for wasm_exec.js
+        fetchSpy.mockImplementation((url: string) => {
+            if (url.endsWith('wasm_exec.js')) {
+                return Promise.resolve({ ok: false });
+            }
+            return Promise.resolve({
+                ok: true,
+                arrayBuffer: () => Promise.resolve(new ArrayBuffer(4))
+            });
+        });
+
+        try {
+            await service.init();
+            throw new Error('Should have thrown an error');
+        } catch (error: any) {
+            expect(error.message).toContain('Failed to fetch wasm_exec.js');
+        }
+    });
+
+    it('should cache files independently', async () => {
+        // First initialization caches both files
+        await service.init();
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        
+        jest.clearAllMocks();
+
+        // Create new instance with only different wasmExecUrl
+        const service2 = new BallotProof({
+            wasmExecUrl: 'http://example.com/different_wasm_exec.js',
+            wasmUrl: 'http://example.com/ballotproof.wasm'
+        });
+
+        // Should only fetch the new wasm_exec.js
+        await service2.init();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/different_wasm_exec.js');
+        
+        jest.clearAllMocks();
+
+        // Create new instance with only different wasmUrl
+        const service3 = new BallotProof({
+            wasmExecUrl: 'http://example.com/wasm_exec.js',
+            wasmUrl: 'http://example.com/different_ballotproof.wasm'
+        });
+
+        // Should only fetch the new ballotproof.wasm
+        await service3.init();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/different_ballotproof.wasm');
+    });
+});

--- a/test/sequencer/unit/CircomProof.test.ts
+++ b/test/sequencer/unit/CircomProof.test.ts
@@ -1,0 +1,155 @@
+import { CircomProof, ProofInputs, Groth16Proof } from '../../../src/sequencer';
+import { groth16 } from 'snarkjs';
+
+// Mock snarkjs groth16
+jest.mock('snarkjs', () => ({
+    groth16: {
+        fullProve: jest.fn().mockResolvedValue({
+            proof: {
+                pi_a: ['1', '2', '3'],
+                pi_b: [['4', '5'], ['6', '7'], ['8', '9']],
+                pi_c: ['10', '11', '12'],
+                protocol: 'groth16',
+                curve: 'bn128'
+            },
+            publicSignals: ['123']
+        })
+    }
+}));
+
+describe('CircomProof caching', () => {
+    let service: CircomProof;
+    let fetchSpy: jest.SpyInstance;
+    
+    // Minimal inputs for testing
+    const testInputs: ProofInputs = {
+        fields: ['1'],
+        max_count: '1',
+        force_uniqueness: '0',
+        max_value: '10',
+        min_value: '0',
+        max_total_cost: '10',
+        min_total_cost: '0',
+        cost_exp: '0',
+        cost_from_weight: '0',
+        address: '1',
+        weight: '1',
+        process_id: '1',
+        pk: ['1', '2'],
+        k: '1',
+        cipherfields: ['1'],
+        nullifier: '1',
+        commitment: '1',
+        secret: '1',
+        inputs_hash: '1'
+    };
+
+    // Mock response for wasm file
+    const mockWasmResponse = new Uint8Array([1, 2, 3, 4]);
+    // Mock response for zkey file
+    const mockZkeyResponse = new Uint8Array([5, 6, 7, 8]);
+
+    beforeEach(() => {
+        // Create a fresh instance for each test
+        service = new CircomProof({
+            wasmUrl: 'http://example.com/circuit.wasm',
+            zkeyUrl: 'http://example.com/proving.zkey'
+        });
+        
+        // Mock fetch to return our test responses
+        global.fetch = jest.fn().mockImplementation((url: string) => {
+            if (url.endsWith('.wasm')) {
+                return Promise.resolve({
+                    ok: true,
+                    arrayBuffer: () => Promise.resolve(mockWasmResponse.buffer)
+                });
+            } else if (url.endsWith('.zkey')) {
+                return Promise.resolve({
+                    ok: true,
+                    arrayBuffer: () => Promise.resolve(mockZkeyResponse.buffer)
+                });
+            }
+            return Promise.reject(new Error(`Unexpected URL: ${url}`));
+        });
+
+        // Spy on fetch after mocking
+        fetchSpy = jest.spyOn(global, 'fetch');
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should cache wasm and zkey files after first generate() call', async () => {
+        // First call should fetch both files
+        await service.generate(testInputs);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/circuit.wasm');
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/proving.zkey');
+
+        // Verify groth16.fullProve was called with cached files
+        expect(groth16.fullProve).toHaveBeenCalledWith(
+            testInputs,
+            expect.any(Uint8Array),
+            expect.any(Uint8Array)
+        );
+
+        // Reset the spy counts
+        jest.clearAllMocks();
+
+        // Second call should use cached files (no new fetches)
+        await service.generate(testInputs);
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(groth16.fullProve).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fetch new files when URLs change', async () => {
+        // First call with original URLs
+        await service.generate(testInputs);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        
+        jest.clearAllMocks();
+
+        // Call with different URLs should fetch new files
+        await service.generate(testInputs, {
+            wasmUrl: 'http://example.com/different.wasm',
+            zkeyUrl: 'http://example.com/different.zkey'
+        });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/different.wasm');
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/different.zkey');
+    });
+
+    it('should handle fetch failures appropriately', async () => {
+        // Mock fetch to fail
+        global.fetch = jest.fn().mockImplementation(() => 
+            Promise.resolve({ ok: false, status: 404 })
+        );
+
+        await expect(service.generate(testInputs)).rejects.toThrow('Failed to fetch');
+    });
+
+    it('should cache files independently', async () => {
+        // First call caches both files
+        await service.generate(testInputs);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        
+        jest.clearAllMocks();
+
+        // Call with only new wasmUrl should fetch only wasm
+        await service.generate(testInputs, {
+            wasmUrl: 'http://example.com/different.wasm'
+        });
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/different.wasm');
+        
+        jest.clearAllMocks();
+
+        // Call with only new zkeyUrl should fetch only zkey
+        await service.generate(testInputs, {
+            zkeyUrl: 'http://example.com/different.zkey'
+        });
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(fetchSpy).toHaveBeenCalledWith('http://example.com/different.zkey');
+    });
+});


### PR DESCRIPTION
The commit adds caching for WASM files in BallotProofService to improve performance and reduces memory usage. It also simplifies API service methods by removing unnecessary async/await syntax and making them more concise. Includes new unit tests for ballot and circom proofs.