### PR TITLE
Add sequencer stats and workers endpoints

### DIFF
--- a/src/sequencer/api/ApiService.ts
+++ b/src/sequencer/api/ApiService.ts
@@ -7,9 +7,11 @@ import {
     GetProcessResponse,
     InfoResponse,
     ListProcessesResponse,
+    SequencerStats,
     VoteBallot,
     VoteRequest, 
     VoteStatusResponse,
+    WorkersResponse,
 } from "./types";
 import { ElectionMetadata } from "../../core";
 
@@ -186,5 +188,19 @@ export class VocdoniApiService extends BaseService {
     getMetadataUrl(hash: string): string {
         if (!isHexString(hash)) throw new Error("Invalid metadata hash format");
         return `${this.axios.defaults.baseURL}/metadata/${hash}`;
+    }
+
+    getStats(): Promise<SequencerStats> {
+        return this.request<SequencerStats>({
+            method: "GET",
+            url: "/sequencer/stats"
+        });
+    }
+
+    getWorkers(): Promise<WorkersResponse> {
+        return this.request<WorkersResponse>({
+            method: "GET",
+            url: "/sequencer/workers"
+        });
     }
 }

--- a/src/sequencer/api/types.ts
+++ b/src/sequencer/api/types.ts
@@ -50,7 +50,6 @@ export interface GetProcessResponse {
     };
     voteCount: string;
     voteOverwriteCount: string;
-    isFinalized: boolean;
     isAcceptingVotes: boolean;
     sequencerStats: {
         stateTransitionCount: number;
@@ -154,4 +153,24 @@ export interface VoteStatusResponse {
 
 export interface ListProcessesResponse {
     processes: string[];
+}
+
+export interface SequencerStats {
+    activeProcesses: number;
+    pendingVotes: number;
+    verifiedVotes: number;
+    aggregatedVotes: number;
+    stateTransitions: number;
+    settledStateTransitions: number;
+    lastStateTransitionDate: string;
+}
+
+export interface WorkerStats {
+    address: string;
+    successCount: number;
+    failedCount: number;
+}
+
+export interface WorkersResponse {
+    workers: WorkerStats[];
 }

--- a/test/sequencer/integration/api/Api.test.ts
+++ b/test/sequencer/integration/api/Api.test.ts
@@ -141,7 +141,6 @@ describe("VocdoniApiService Integration", () => {
         const process = await api.getProcess(processes[0]);
         expect(typeof process.voteCount).toBe('string');
         expect(typeof process.voteOverwriteCount).toBe('string');
-        expect(typeof process.isFinalized).toBe('boolean');
         expect(typeof process.isAcceptingVotes).toBe('boolean');
         expect(process).toHaveProperty('sequencerStats');
         const { sequencerStats } = process;
@@ -197,5 +196,35 @@ describe("VocdoniApiService Integration", () => {
 
     it("should delete the census", async () => {
         await expect(api.deleteCensus(censusId)).resolves.toBeUndefined();
+    });
+
+    describe("Sequencer statistics", () => {
+        it("should get sequencer stats", async () => {
+            const stats = await api.getStats();
+            
+            expect(typeof stats.activeProcesses).toBe('number');
+            expect(typeof stats.pendingVotes).toBe('number');
+            expect(typeof stats.verifiedVotes).toBe('number');
+            expect(typeof stats.aggregatedVotes).toBe('number');
+            expect(typeof stats.stateTransitions).toBe('number');
+            expect(typeof stats.settledStateTransitions).toBe('number');
+            expect(typeof stats.lastStateTransitionDate).toBe('string');
+            
+            // Validate date format
+            expect(new Date(stats.lastStateTransitionDate).toString()).not.toBe('Invalid Date');
+        });
+
+        it("should get workers stats", async () => {
+            const response = await api.getWorkers();
+            
+            expect(Array.isArray(response.workers)).toBe(true);
+            
+            // Check each worker's structure
+            response.workers.forEach(worker => {
+                expect(typeof worker.address).toBe('string');
+                expect(typeof worker.successCount).toBe('number');
+                expect(typeof worker.failedCount).toBe('number');
+            });
+        });
     });
 });


### PR DESCRIPTION
Implements new API endpoints to fetch sequencer statistics and worker information. Adds SequencerStats and WorkersResponse types, and removes deprecated isFinalized field from GetProcessResponse. Includes integration tests for new endpoints.