### PR TITLE
chore(build): 🧹 add clean-package to optimize package output and simp…

### DIFF
--- a/clean-package.config.json
+++ b/clean-package.config.json
@@ -1,0 +1,22 @@
+{
+  "replace": {
+    "main": "dist/contracts.js",
+    "module": "dist/contracts.mjs",
+    "types": "dist/contracts.d.ts",
+    "exports": {
+      "./contracts": {
+        "types": "./dist/types.d.ts",
+        "import": "./dist/contracts.mjs",
+        "require": "./dist/contracts.js"
+      },
+      "./sequencer": {
+        "types": "./dist/types.d.ts",
+        "import": "./dist/sequencer.mjs",
+        "require": "./dist/sequencer.js"
+      },
+      "./types": "./dist/types.d.ts",
+      "./package.json": "./package.json"
+    }
+  },
+  "remove": ["clean-package"]
+}

--- a/package.json
+++ b/package.json
@@ -1,21 +1,12 @@
 {
-  "name": "davinci-sdk",
+  "name": "@vocdoni/davinci-sdk",
   "version": "0.0.1",
   "type": "module",
-  "main": "dist/contracts.js",
-  "module": "dist/contracts.mjs",
-  "types": "dist/contracts.d.ts",
+  "main": "src/index.ts",
   "exports": {
-    "./contracts": {
-      "types": "./dist/contracts.d.ts",
-      "import": "./dist/contracts.mjs",
-      "require": "./dist/contracts.js"
-    },
-    "./sequencer": {
-      "types": "./dist/sequencer.d.ts",
-      "import": "./dist/sequencer.mjs",
-      "require": "./dist/sequencer.js"
-    }
+    "./contracts": "./src/contracts/index.ts",
+    "./sequencer": "./src/sequencer/index.ts",
+    "./types": "./src/core/types/index.ts"
   },
   "scripts": {
     "clean": "rimraf dist",
@@ -26,6 +17,8 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint-staged": "lint-staged",
+    "prepack": "clean-package",
+    "postpack": "mv -fv package.json.backup package.json",
     "test": "yarn test:unit && yarn test:integration",
     "test:unit": "yarn test:contracts:unit && yarn test:sequencer:unit",
     "test:integration": "yarn test:contracts:integration && yarn test:sequencer:integration",
@@ -46,7 +39,6 @@
     "snarkjs": "^0.7.5"
   },
   "devDependencies": {
-    "lint-staged": "^15.2.0",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
@@ -54,10 +46,12 @@
     "@types/node": "^20.5.9",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
+    "clean-package": "^2.2.0",
     "dotenv": "^16.4.7",
     "esbuild": "^0.25.2",
     "eslint": "^8.48.0",
     "jest": "^29.7.0",
+    "lint-staged": "^15.2.0",
     "prettier": "^3.0.3",
     "rimraf": "^5.0.1",
     "rollup": "^4.0.0",
@@ -67,5 +61,6 @@
     "rollup-plugin-polyfill-node": "^0.13.0",
     "ts-jest": "^29.3.1",
     "typescript": "^5.2.2"
-  }
+  },
+  "clean-package": "./clean-package.config.json"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
-import { createRequire } from 'module';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
+import { createRequire } from 'module';
 import dts from 'rollup-plugin-dts';
 import esbuild from 'rollup-plugin-esbuild';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
@@ -12,7 +12,7 @@ const pkg = require('./package.json');
 const createBundle = (config, options) => ({
   ...config,
   input: options.input,
-  external: Object.keys(pkg.dependencies || {}).filter(dep => 
+  external: Object.keys(pkg.dependencies || {}).filter(dep =>
     options.includeSnarkjs ? true : dep !== 'snarkjs'
   ),
 });
@@ -25,83 +25,67 @@ const createOutput = (name, options) => [
     file: `dist/${name}.umd.js`,
     format: 'umd',
     globals: {
-      'axios': 'axios',
+      axios: 'axios',
       '@vocdoni/davinci-contracts': 'davinciContracts',
-      'ethers': 'ethers',
-      'snarkjs': 'snarkjs',
-      '@ethereumjs/common': 'ethereumjsCommon'
-    }
-  }
+      ethers: 'ethers',
+      snarkjs: 'snarkjs',
+      '@ethereumjs/common': 'ethereumjsCommon',
+    },
+  },
 ];
 
 export default [
   // Core bundle
-  createBundle({
-    plugins: [
-      json(),
-      commonjs(),
-      resolve(),
-      esbuild({ target: 'esnext' })
-    ],
-    output: createOutput('core', { umdName: 'CoreSDK' })
-  }, {
-    input: 'src/core/index.ts',
-    includeSnarkjs: false
-  }),
-  
-  // Core types
-  createBundle({
-    plugins: [dts()],
-    output: { file: 'dist/core.d.ts', format: 'es' }
-  }, {
-    input: 'src/core/index.ts',
-    includeSnarkjs: false
-  }),
+  createBundle(
+    {
+      plugins: [json(), commonjs(), resolve(), esbuild({ target: 'esnext' })],
+      output: createOutput('core', { umdName: 'CoreSDK' }),
+    },
+    {
+      input: 'src/core/index.ts',
+      includeSnarkjs: false,
+    }
+  ),
 
   // Contracts bundle
-  createBundle({
-    plugins: [
-      json(),
-      commonjs(),
-      resolve(),
-      esbuild({ target: 'esnext' })
-    ],
-    output: createOutput('contracts', { umdName: 'ContractsSDK' })
-  }, {
-    input: 'src/contracts/index.ts',
-    includeSnarkjs: true
-  }),
-  
-  // Contracts types
-  createBundle({
-    plugins: [dts()],
-    output: { file: 'dist/contracts.d.ts', format: 'es' }
-  }, {
-    input: 'src/contracts/index.ts',
-    includeSnarkjs: true
-  }),
-  
+  createBundle(
+    {
+      plugins: [json(), commonjs(), resolve(), esbuild({ target: 'esnext' })],
+      output: createOutput('contracts', { umdName: 'ContractsSDK' }),
+    },
+    {
+      input: 'src/contracts/index.ts',
+      includeSnarkjs: true,
+    }
+  ),
+
   // Sequencer bundle
-  createBundle({
-    plugins: [
-      json(),
-      commonjs(),
-      resolve({ browser: true }),
-      nodePolyfills(),
-      esbuild({ target: 'esnext' })
-    ],
-    output: createOutput('sequencer', { umdName: 'SequencerSDK' })
-  }, {
-    input: 'src/sequencer/index.ts',
-    includeSnarkjs: false
-  }),
-  
-  // Sequencer types
-  createBundle({
-    plugins: [dts()],
-    output: { file: 'dist/sequencer.d.ts', format: 'es' }
-  }, {
-    input: 'src/sequencer/index.ts',
-    includeSnarkjs: false
-  })
+  createBundle(
+    {
+      plugins: [
+        json(),
+        commonjs(),
+        resolve({ browser: true }),
+        nodePolyfills(),
+        esbuild({ target: 'esnext' }),
+      ],
+      output: createOutput('sequencer', { umdName: 'SequencerSDK' }),
+    },
+    {
+      input: 'src/sequencer/index.ts',
+      includeSnarkjs: false,
+    }
+  ),
+
+  // Types
+  createBundle(
+    {
+      plugins: [dts()],
+      output: { file: 'dist/types.d.ts', format: 'es' },
+    },
+    {
+      input: 'src/core/types/index.ts',
+      includeSnarkjs: false,
+    }
+  ),
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1551,6 +1551,13 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz#0f79731eb8cfe1ec72acd4066efac9d61991b00d"
   integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
 
+clean-package@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-package/-/clean-package-2.2.0.tgz#8348b131c60a785457173f0e34129269835a2833"
+  integrity sha512-vLv8kRqvh4smPDpqAYFPLEijTppAd/cfCz4yBcUGoVl/JKu6ZWKhlo+G/cAmwlSa29RudfBeuyiNEzas8bTwEQ==
+  dependencies:
+    dot-prop "^6.0.1"
+
 cli-cursor@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
@@ -1706,6 +1713,13 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dot-prop@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
+  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
+  dependencies:
+    is-obj "^2.0.0"
 
 dotenv@^16.4.7:
   version "16.5.0"
@@ -2501,6 +2515,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
 is-path-inside@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
This fixes the need to build the package after installing it via a non npm registry, but also requires anyone importing it via these methods to be using some sort of typescript compiler.

I had to mess a bit with the rollup config since what's done with the types export was required in order to have a coherent way to import types both before and after the bundling is done. So right now, all types are exported onto a single file, which is exported via the `/types` export. This is also helpful in case some type was used in both exports, since otherwise we were duplicating code.

I've also added an `.npmignore` file to ensure no unnecessary files were added to the final package, which tempted me to remove the `sourcemap` generation, since they're only used during development and have a huge impact in the final pack file size... but I leave that open to debate.