### PR TITLE
Add GitHub Pages deployment workflow for UI example

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,0 +1,68 @@
+name: Deploy UI to GitHub Pages
+
+on:
+  pull_request:
+    types: [labeled]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    if: contains(github.event.label.name, 'deploy-ui')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        
+      - name: Build SDK
+        run: yarn build
+        
+      - name: Install UI dependencies
+        run: |
+          cd examples/ui
+          yarn install
+        
+      - name: Build with Next.js
+        run: |
+          cd examples/ui
+          yarn build
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          SEPOLIA_RPC: ${{ secrets.SEPOLIA_RPC }}
+          ESLINT_NO_DEV_ERRORS: true
+          
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./examples/ui/out
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/examples/ui/.gitignore
+++ b/examples/ui/.gitignore
@@ -9,6 +9,8 @@
 !.yarn/plugins
 !.yarn/releases
 !.yarn/versions
+yarn.lock
+davinci-sdk.tgz
 
 # testing
 /coverage


### PR DESCRIPTION
- Deploy UI to GitHub Pages when PR is labeled with 'deploy-ui'
- Build SDK before packing to include dist files
- Handle yarn.lock conflicts by ignoring in UI directory
- Use environment variables from GitHub Secrets for API_URL and SEPOLIA_RPC