### PR TITLE
Fix GitHub Pages asset loading with basePath configuration

### DIFF
--- a/examples/ui/next.config.js
+++ b/examples/ui/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   output: 'export',
   trailingSlash: true,
+  basePath: '/davinci-sdk',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
- Add basePath: '/davinci-sdk' to next.config.js
- Fixes 404 errors for _next/static assets on GitHub Pages
- Assets will now load from correct path: /davinci-sdk/_next/static/